### PR TITLE
Add concurrency_method to the schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -648,7 +648,7 @@
         "concurrency_method": {
           "type": "string",
           "enum": ["ordered", "eager"]
-          "description": "How concurrency is controled, allows values are 'ordered' (default) and 'eager'",
+          "description": "Control command order, allowed values are 'ordered' (default) and 'eager'.  If you use this attribute, you must also define concurrency_group and concurrency.",
           "examples": [
             "ordered"
           ]

--- a/schema.json
+++ b/schema.json
@@ -645,6 +645,14 @@
             "my-pipeline/deploy"
           ]
         },
+        "concurrency_method": {
+          "type": "string",
+          "enum": ["ordered", "eager"]
+          "description": "How concurrency is controled, allows values are 'ordered' (default) and 'eager'",
+          "examples": [
+            "ordered"
+          ]
+        },
         "depends_on": {
           "$ref": "#/definitions/commonOptions/dependsOn"
         },

--- a/test/valid-pipelines/command.yml
+++ b/test/valid-pipelines/command.yml
@@ -53,6 +53,7 @@ steps:
   - command: test
     concurrency: 1
     concurrency_group: "my-group"
+    concurrency_method: "eager"
 
   - command: test
     env:


### PR DESCRIPTION
This field controls exactly how concurrent steps executed are when using
concurrency control, as mentioned here:
https://buildkite.com/docs/pipelines/controlling-concurrency#concurrency-and-parallelism-controlling-command-order